### PR TITLE
Fix: Expired access token 

### DIFF
--- a/Classes/Mautic/AuthorizationFactory.php
+++ b/Classes/Mautic/AuthorizationFactory.php
@@ -61,6 +61,22 @@ class AuthorizationFactory implements SingletonInterface
             $settings['accessToken'] ?? '',
             $extensionConfiguration->getAuthorizeMode()
         );
+        
+        /** @var MauticAuthorizeService $authorizeService */
+        $authorizeService = GeneralUtility::makeInstance(
+            MauticAuthorizeService::class,
+            self::$oAuth,
+            false
+        );
+
+        if ($authorizeService->validateCredentials() === true) {
+            if (!$authorizeService->validateAccessToken()) {
+                if ($authorizeService->accessTokenToBeRefreshed()) {
+                    $authorizeService->refreshAccessToken();
+                    $extensionConfiguration->reloadConfigurations();
+                }
+            }
+        }
 
         return self::$oAuth;
     }

--- a/Classes/Mautic/AuthorizationFactory.php
+++ b/Classes/Mautic/AuthorizationFactory.php
@@ -16,6 +16,7 @@ namespace Bitmotion\Mautic\Mautic;
 
 use Bitmotion\Mautic\Domain\Model\Dto\YamlConfiguration;
 use Bitmotion\Mautic\Middleware\AuthorizeMiddleware;
+use Bitmotion\Mautic\Service\MauticAuthorizeService;
 use Mautic\Auth\ApiAuth;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;


### PR DESCRIPTION
Based on the suggestion from @Moongazer in #75 I updated `AuthorizationFactory::createAuthorizationFromExtensionConfiguration()` and added some code to validate and update the access token. I took the original code from `BackendController.php` and changed it a little bit.

I did some tests and the file access and loading of mautic properties in the form module are working fine in my test environment.