### PR TITLE
Fix for v4.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "typo3/cms-core": "^10.4.2 || ^11.5",
         "typo3/cms-extbase": "^10.4.2 || ^11.5",
         "leuchtfeuer/marketing-automation": "^1.3",
-        "mautic/api-library": "^2.15"
+		"mautic/api-library": "^3.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "docs": "https://docs.typo3.org/p/mautic/mautic-typo3/master/en-us/"
     },
     "require": {
+		"php": "<=7.4",
         "typo3/cms-core": "^10.4.2 || ^11.5",
         "typo3/cms-extbase": "^10.4.2 || ^11.5",
         "leuchtfeuer/marketing-automation": "^1.3",


### PR DESCRIPTION
Make sure the extension is used only on PHP 7.4 systems, because the current version of mautic/api-library will fail during OAuth on PHP 8 systems.
