### PR TITLE
Set PHP requirement to <8.0 to allow all minor PHP versions until 7.4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "docs": "https://docs.typo3.org/p/mautic/mautic-typo3/master/en-us/"
     },
     "require": {
-		"php": "<=7.4",
+		"php": "<8.0",
         "typo3/cms-core": "^10.4.2 || ^11.5",
         "typo3/cms-extbase": "^10.4.2 || ^11.5",
         "leuchtfeuer/marketing-automation": "^1.3",


### PR DESCRIPTION
Set PHP requirement to <8.0 to allow all minor PHP versions until 7.4.x (which have been excluded earlier)