### PR TITLE
[FIX] Authentication header for bearer access-token was set twice by …

### DIFF
--- a/Classes/Mautic/OAuth.php
+++ b/Classes/Mautic/OAuth.php
@@ -66,7 +66,7 @@ class OAuth implements AuthInterface
     }
 
     /**
-     * Make a request to server using the supported auth method
+     * Make a request to server
      *
      * @param string $url
      * @param string $method
@@ -75,10 +75,6 @@ class OAuth implements AuthInterface
      */
     public function makeRequest($url, array $parameters = [], $method = 'GET', array $settings = [])
     {
-        if ($this->authorizationMode !== YamlConfiguration::OAUTH1_AUTHORIZATION_MODE && $method !== 'GET') {
-            $settings['headers']['Authorization'] = sprintf('Authorization: Bearer %s', $this->accesToken);
-        }
-
         return $this->authorization->makeRequest($url, $parameters, $method, $settings);
     }
 }


### PR DESCRIPTION
[FIX] Authentication header for bearer access-token was set twice by this extension and by api-library, which resulted in a 400 Bad response from Nginx (see #80)