### PR TITLE
Add forked dependency of mautic/api-library

### DIFF
--- a/Configuration/TCA/tx_mautic_domain_model_tag.php
+++ b/Configuration/TCA/tx_mautic_domain_model_tag.php
@@ -16,7 +16,7 @@ return [
             'default' => 'mimetypes-x-tx_marketingautomation_persona',
         ],
         'hideTable' => true,
-        'rootLevel' => true,
+        'rootLevel' => 1,
         'security' => [
             'ignoreRootLevelRestriction' => true,
         ],

--- a/README.md
+++ b/README.md
@@ -9,7 +9,20 @@ Welcome to the official Mautic extension for TYPO3.
 
 Both currently support Mautic v4.
 
-TYPO3 on **PHP8 is NOT supported** with Mautic4 (because the Mautic project does not provide PHP8 support for the Mautic4 API library). This will only change with Mautic5 (or enough people are willing to support a custom solution - please get in touch!)
+## ⚠️ IMPORTANT
+> To install this extension on PHP 8 systems, you MUST add the following repository URL to your root `composer.json`:
+```json
+"repositories": [
+  {
+    "url": "https://github.com/Leuchtfeuer/api-library.git",
+    "type": "git"
+  }
+]
+ ```
+> Than install the extension by running `composer require mautic/mautic-typo3`.
+> The reason is that we have to use a forked version of `mautic/api-library` which is PHP 8 compatible, until an official
+> library version for PHP 8 is released (It should come with the release of Mautic 5).
+
 
 ## Features
 The Mautic TYPO3 extension has many features that allow you to integrate your marketing automation workflow in TYPO3.

--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,11 @@
         "docs": "https://docs.typo3.org/p/mautic/mautic-typo3/master/en-us/"
     },
     "require": {
-		"php": "<8.0",
-        "typo3/cms-core": "^10.4.2 || ^11.5",
-        "typo3/cms-extbase": "^10.4.2 || ^11.5",
+		"php": ">=8.0",
+        "typo3/cms-core": "^11.5",
+        "typo3/cms-extbase": "^11.5",
         "leuchtfeuer/marketing-automation": "^1.3",
-		"mautic/api-library": "^3.1"
+		"mautic/api-library": "^4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Add forked dependency of mautic/api-library to allow this extension to run on PHP 8 systems (see README for more information)

This should be released as different minor-version, e.g. v4.4.0:
- v4.3.x will support TYPO3 v11 on PHP 7
- v4.4.x will support TYPO3 v11 on PHP 8