### PR TITLE
[FIX] Set the correct record UID in data-handler after the tag-sync

### DIFF
--- a/Classes/Domain/Repository/TagRepository.php
+++ b/Classes/Domain/Repository/TagRepository.php
@@ -56,6 +56,20 @@ class TagRepository extends AbstractRepository
         }
     }
 
+    /**
+     * @throws \Doctrine\DBAL\DBALException
+     * @throws \Doctrine\DBAL\Driver\Exception
+     */
+    public function findTagByTitle(string $title): array
+    {
+        $queryBuilder = $this->getQueryBuilder();
+        $result = $queryBuilder->select('*')
+            ->from('tx_mautic_domain_model_tag')
+            ->where($queryBuilder->expr()->eq('title', $queryBuilder->createNamedParameter($title, \PDO::PARAM_STR)))
+            ->execute();
+        return $result->fetchAssociative();
+    }
+
     protected function updateTag(array $tag, int $time)
     {
         $queryBuilder = $this->getQueryBuilder();

--- a/Classes/Hooks/TCEmainHook.php
+++ b/Classes/Hooks/TCEmainHook.php
@@ -24,7 +24,7 @@ class TCEmainHook
     /**
      * Create tags in Mautic and synchronize them with TYPO3 to receive proper IDs
      */
-    public function processDatamap_afterDatabaseOperations(string $status, string $table, string $id, array $fields, DataHandler &$dataHandler)
+    public function processDatamap_afterDatabaseOperations(string $status, string $table, string $id, array $fields, DataHandler &$dataHandler): void
     {
         if ($status === 'new' && $table === 'tx_mautic_domain_model_tag' && !empty($fields['title'])) {
             // Dirty way to create tags in Mautic
@@ -35,6 +35,14 @@ class TCEmainHook
             // Synchronize tags to receive proper ids
             $tagRepository = GeneralUtility::makeInstance(TagRepository::class);
             $tagRepository->synchronizeTags();
+
+            // update record UID to display edit-form after syncing the new tag with Mautic to avoid error in case the
+            // AUTO_INCREMENT value of table 'tx_mautic_domain_model_tag' is different from Mautic's 'lead_tags' table
+            // (see issue https://github.com/mautic/mautic-typo3/issues/82)
+            $newTag = $tagRepository->findTagByTitle($fields['title']);
+            if (!empty($newTag) && $newTag['uid'] !== $dataHandler->substNEWwithIDs[$id]) {
+                $dataHandler->substNEWwithIDs[$id] = $newTag['uid'];
+            }
         }
     }
 }


### PR DESCRIPTION
[FIX] Set the correct record UID in data-handler after the tag-sync process, in case the AUTO_INCREMENT counter for the tag-tables in both databases (TYPO3/Mautic) are not equal (see issue #82)