### PR TITLE
TASK: Fixed form synchronization with Mautic v5

### DIFF
--- a/Classes/Hooks/MauticFormHook.php
+++ b/Classes/Hooks/MauticFormHook.php
@@ -235,9 +235,12 @@ class MauticFormHook implements LoggerAwareInterface
      */
     protected function transformFormElements()
     {
+        $fieldDefinitions = $this->formTransformation->getFields();
+        $this->formTransformation->setFields([]);
         foreach ($this->formTransformation->getFormElements() as $formElement) {
             $fieldTransformation = $this->getFieldTransformation($formElement);
             $fieldTransformation->transform();
+            $fieldTransformation->enrichFieldData($fieldDefinitions);
             $this->formTransformation->addField($fieldTransformation->getFieldData());
             if ($fieldTransformation instanceof ListTransformationPrototype && $fieldTransformation->hasCustomFieldValues()) {
                 $this->formTransformation->addCustomFieldValues($fieldTransformation->getCustomFieldValues());

--- a/Classes/Transformation/Form/AbstractFormTransformation.php
+++ b/Classes/Transformation/Form/AbstractFormTransformation.php
@@ -90,6 +90,16 @@ abstract class AbstractFormTransformation extends AbstractTransformation impleme
         }
     }
 
+    public function getFields(): array
+    {
+        return $this->formData['fields'] ?? [];
+    }
+
+    public function setFields(array $fieldDefinitions): void
+    {
+        $this->formData['fields'] = $fieldDefinitions;
+    }
+
     public function getUpdatedFormDefinition(array $response): array
     {
         if ($this->isFormDefinitionUpdated === false) {

--- a/Classes/Transformation/FormField/AbstractFormFieldTransformation.php
+++ b/Classes/Transformation/FormField/AbstractFormFieldTransformation.php
@@ -100,4 +100,20 @@ abstract class AbstractFormFieldTransformation extends AbstractTransformation im
 
         $this->fieldData = $fieldData;
     }
+
+    public function enrichFieldData(array $fieldDefinitions): void
+    {
+        if (empty($this->fieldData['id'])) {
+            return;
+        }
+
+        $fieldDefinitions = array_filter($fieldDefinitions, function ($fieldDefinition) {return $fieldDefinition['id'] ?? null === $this->fieldData['id'];});
+        $fieldDefinition = array_shift($fieldDefinitions);
+
+        if (empty($fieldDefinition)) {
+            return;
+        }
+
+        $this->fieldData = array_replace($fieldDefinition, $this->fieldData);
+    }
 }


### PR DESCRIPTION
Only the fields of the TYPO3 form should be synchronized with the Mautic form, not vice versa.

This paradigm also fixes the Mautic 5 error "Another field is already using this alias: <field-alias>. Please choose another or leave blank to have it autogenerated." which was triggered by sending the collected field configurations from Mautic and TYPO3 to the Mautic API.

See: https://github.com/mautic/mautic/pull/13599